### PR TITLE
Fixed remotezip.py to work for Python3.x

### DIFF
--- a/pyremotezip/remotezip.py
+++ b/pyremotezip/remotezip.py
@@ -28,7 +28,7 @@ class RemoteZip(object):
             response = urllib2.urlopen(headRequest)
             self.filesize = int(response.info().getheader('Content-Length'))
             return True
-        except HTTPError, e:
+        except HTTPError as e:
             print '%s' % e
             return False
 


### PR DESCRIPTION
Before that, it raised SyntaxError at line 32.
File "build/bdist.linux-x86_64/egg/pyremotezip/remotezip.py", line 32
    print '%s' % e
             ^
SyntaxError: invalid syntax
